### PR TITLE
Fix crash when UpdaterService is started for the first time

### DIFF
--- a/app/src/main/java/com/chiller3/custota/Notifications.kt
+++ b/app/src/main/java/com/chiller3/custota/Notifications.kt
@@ -88,6 +88,7 @@ class Notifications(
         actions: List<Pair<Int, Intent>>,
         progressCurrent: Int?,
         progressMax: Int?,
+        showImmediately: Boolean,
     ): Notification {
         require((progressCurrent == null) == (progressMax == null)) {
             "Must specify both current and max progress or neither"
@@ -135,7 +136,9 @@ class Notifications(
             }
 
             // Inhibit 10-second delay when showing persistent notification
-            setForegroundServiceBehavior(Notification.FOREGROUND_SERVICE_IMMEDIATE)
+            if (showImmediately) {
+                setForegroundServiceBehavior(Notification.FOREGROUND_SERVICE_IMMEDIATE)
+            }
 
             build()
         }


### PR DESCRIPTION
On the initial installation of Custota, the first app launch will set up the periodic updater job and Android will fire up one run of UpdaterService almost immediately. UpdaterService is started with startForegroundService() and because the user hasn't had the chance to configure a URL yet, the service immediately calls stopService() and exits. This is not allowed by Android. Even if a service immediately exits, it must still call startForeground().

This commit adds the startForeground() call whenever UpdaterService runs, even if there's nothing to do. To avoid a pointless notification being shown, the FOREGROUND_SERVICE_IMMEDIATE is not used unless an actual update check is going to be run.

Fixes: #7