### PR TITLE
post-fs-data.sh: Explicitly create /dev/selinux

### DIFF
--- a/app/module/post-fs-data.sh
+++ b/app/module/post-fs-data.sh
@@ -18,6 +18,8 @@ header Creating custota_app domain
 
 header Updating seapp_contexts
 
+mkdir -p /dev/selinux
+
 cat >> /dev/selinux/apex_seapp_contexts << EOF
 user=_app isPrivApp=true name=${app_id} domain=custota_app type=app_data_file levelFrom=all
 EOF


### PR DESCRIPTION
First stage `init` no longer creates the directory unconditionally [1]. It only does so if there's actually an APEX-packaged SELinux policy.

[1] https://android.googlesource.com/platform/system/core/+/d01921034cc63c9f0942b5fb451cbc971e7407b1%5E%21/

Issue: #11