### PR TITLE
custota-tool: Fix missing value_parser for --cert

### DIFF
--- a/custota-tool/src/main.rs
+++ b/custota-tool/src/main.rs
@@ -116,7 +116,7 @@ struct GenerateCsig {
     passphrase_file: Option<PathBuf>,
 
     /// Path to certificate for signing csig.
-    #[arg(short, long)]
+    #[arg(short, long, value_parser)]
     cert: PathBuf,
 
     /// Path to certificate for verifying OTA.


### PR DESCRIPTION
This fixes passing non-UTF-8 paths for `--cert` on Linux.