### PR TITLE
Switch to special use foreground service type

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ This creates a Magisk/KernelSU module that overrides `otacerts.zip`. After flash
   * Needed to store temporary OTA files.
 * `ACCESS_NETWORK_STATE` (**automatically granted at install time**)
   * Needed on Android 14+ for unmetered network background run condition.
-* `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_SYSTEM_EXEMPTED` (**automatically granted at install time**)
+* `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_SPECIAL_USE` (**automatically granted at install time**)
   * Needed to run the OTA update service in the background.
 * `INTERNET` (**automatically granted at install time**)
   * Needed to communicate with the OTA server. Custota **does not and will never** communicate with any server outside of the configured OTA server. There are no ads, analytics, or any sort of tracking.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"
         android:minSdkVersion="34" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED"
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"
         android:minSdkVersion="34" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.MANAGE_CARRIER_OEM_UNLOCK_STATE"
@@ -44,7 +44,7 @@
 
         <service
             android:name=".updater.UpdaterService"
-            android:foregroundServiceType="systemExempted"
+            android:foregroundServiceType="specialUse"
             android:exported="false" />
 
         <activity

--- a/app/src/main/java/com/chiller3/custota/updater/UpdaterService.kt
+++ b/app/src/main/java/com/chiller3/custota/updater/UpdaterService.kt
@@ -181,7 +181,7 @@ class UpdaterService : Service(), UpdaterThread.UpdaterThreadListener {
         )
 
         val type = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            ServiceInfo.FOREGROUND_SERVICE_TYPE_SYSTEM_EXEMPTED
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
         } else {
             0
         }


### PR DESCRIPTION
GrapheneOS 14 introduced [1], which unconditionally changes the system exempted foreground type to the special use foreground type within `ServiceInfo`. This applies to all packages, not just gmscompat-related packages.

However, they don't wrap the corresponding `startForeground()` calls, so the mismatch causes Custota's service to crash. We can work around this GrapheneOS bug by switching to the special use foreground type, which currently has no downsides compared to the system exempted foreground type.

Fixes: #22

[1]: https://github.com/GrapheneOS/platform_frameworks_base/commit/a350b31d35d2218d0c8ba69772d5b1b95f92c236