### PR TITLE
Switch to modifying /system/etc/selinux/plat_seapp_contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ There are two parts to the SELinux changes:
 
 1. There's a [`custota_selinux` native executable](./app/src/main/cpp/custota_selinux) that performs all of the policy modifications. It takes the `untrusted_app` domain and makes a copy of it as `custota_app`. Then, it adds the relevant rules to allow only `custota_app` to access `update_engine`. The domain is copied from `untrusted_app` instead of the normal `priv_app` domain that is assigned to system apps because Custota does not require any of the additional privileges that would have been granted by `priv_app`.
 
-2. An `seapp_contexts` rule is added to `/dev/selinux/apex_seapp_contexts`, which actually sets up the association between Custota (app package ID: `com.chiller3.custota`) and the new SELinux domain (`custota_app`).
+2. An `seapp_contexts` rule is added to `/system/etc/selinux/plat_seapp_contexts`, which actually sets up the association between Custota (app package ID: `com.chiller3.custota`) and the new SELinux domain (`custota_app`).
 
 These changes help limit Custota's privileges to exactly what is needed and avoids potentially increasing the attack surface via other apps.
 

--- a/app/module/post-fs-data.sh
+++ b/app/module/post-fs-data.sh
@@ -1,14 +1,10 @@
-# SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+# SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
 # SPDX-License-Identifier: GPL-3.0-only
 
 # We don't want to give any arbitrary system app permissions to update_engine.
 # Thus, we create a new context for custota and only give access to that
 # specific type. Magisk currently has no builtin way to modify seapp_contexts,
 # so we'll do it manually.
-#
-# Android's fork of libselinux looks at /dev/selinux/apex_seapp_contexts. It's
-# currently not used, but may be used in the future for selinux policy updates
-# delivered via an apex image.
 
 source "${0%/*}/boot_common.sh" /data/local/tmp/custota_selinux.log
 
@@ -18,10 +14,25 @@ header Creating custota_app domain
 
 header Updating seapp_contexts
 
-mkdir -p /dev/selinux
+seapp_dir=/system/etc/selinux
+seapp_file=${seapp_dir}/plat_seapp_contexts
+mod_seapp_dir=${mod_dir}${seapp_dir}
+mod_seapp_file=${mod_dir}${seapp_file}
 
-cat >> /dev/selinux/apex_seapp_contexts << EOF
+rm -rf "${mod_seapp_dir}"
+mkdir -p "${mod_seapp_dir}"
+
+# If, for whatever reason, we couldn't wipe the directory, mount a blank tmpfs
+# on top. An outdated file can cause the system to boot loop due to system apps
+# running under the wrong SELinux context.
+if [[ -e "${mod_seapp_file}" ]]; then
+    mount -t tmpfs tmpfs "${mod_seapp_dir}"
+fi
+
+# Full path because Magisk runs this script in busybox's standalone ash mode and
+# we need Android's toybox version of cp.
+/system/bin/cp --preserve=a "${seapp_file}" "${mod_seapp_file}"
+
+cat >> "${mod_seapp_file}" << EOF
 user=_app isPrivApp=true name=${app_id} domain=custota_app type=app_data_file levelFrom=all
 EOF
-
-restorecon -Rv /dev/selinux


### PR DESCRIPTION
Android 14 QPR2 (2024 March security update) dropped support for loading APEX SELinux policies [1] and thus, /dev/selinux/apex_seapp_contexts.

This commit updates the post-fs-data hook script to modify /system/etc/selinux/plat_seapp_contexts instead, which is the only other file that's applicable to apps stored on the system partition. The hook script takes extra care to ensure that an outdated modified version of this file won't be loaded because that can result in boot loops.

[1] https://android.googlesource.com/platform/external/selinux/+/e9448817b37b2d14ab8e00dfff4b60347512aae7%5E%21/

Fixes: #40