### PR TITLE
Add debug feature for installing custom csig validation certs

### DIFF
--- a/app/src/main/java/com/chiller3/custota/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/chiller3/custota/settings/SettingsViewModel.kt
@@ -1,14 +1,17 @@
 /*
- * SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
 package com.chiller3.custota.settings
 
+import android.app.Application
+import android.net.Uri
 import android.service.oemlock.IOemLockService
 import android.util.Log
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.chiller3.custota.Preferences
 import com.chiller3.custota.extension.toSingleLineString
 import com.chiller3.custota.updater.OtaPaths
 import com.chiller3.custota.wrapper.ServiceManagerProxy
@@ -18,32 +21,94 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.IOException
+import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
 
-class SettingsViewModel : ViewModel() {
-    private val _certs = MutableStateFlow<List<X509Certificate>>(emptyList())
-    val certs: StateFlow<List<X509Certificate>> = _certs
+class SettingsViewModel(application: Application) : AndroidViewModel(application) {
+    private val prefs = Preferences(getApplication())
+
+    private val _certs = MutableStateFlow<List<Pair<X509Certificate, Boolean>>>(emptyList())
+    val certs: StateFlow<List<Pair<X509Certificate, Boolean>>> = _certs
 
     private val _bootloaderStatus = MutableStateFlow<BootloaderStatus?>(null)
     val bootloaderStatus: StateFlow<BootloaderStatus?> = _bootloaderStatus
 
     init {
-        loadCertificates()
+        loadCerts()
     }
 
-    private fun loadCertificates() {
+    private fun loadCerts() {
         viewModelScope.launch {
-            withContext(Dispatchers.IO) {
-                val certs = try {
+            val systemCerts = try {
+                withContext(Dispatchers.IO) {
                     OtaPaths.otaCerts
-                } catch (e: Exception) {
-                    Log.w(TAG, "Failed to load certificates")
-                    emptyList()
                 }
-
-                _certs.update { certs }
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to load system certificates", e)
+                emptySet()
             }
+
+            val csigCerts = try {
+                // Avoid duplicates.
+                prefs.csigCerts.subtract(systemCerts)
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to load user csig certificates", e)
+                emptySet()
+            }
+
+            _certs.update { systemCerts.sortedWith(certCompare).map { it to true } +
+                    csigCerts.sortedWith(certCompare).map { it to false } }
         }
+    }
+
+    fun installCsigCert(uri: Uri) {
+        viewModelScope.launch {
+            val cert = try {
+                withContext(Dispatchers.IO) {
+                    val factory = CertificateFactory.getInstance("X.509")
+
+                    getApplication<Application>().contentResolver.openInputStream(uri)?.use {
+                        factory.generateCertificate(it) as X509Certificate
+                    } ?: throw IOException("Null input stream: $uri")
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to load certificate: $uri")
+                return@launch
+            }
+
+            val allCerts = _certs.value
+
+            if (allCerts.any { it.first == cert }) {
+                Log.w(TAG, "Certificate already exists: $cert")
+                return@launch
+            }
+
+            Log.d(TAG, "Installing user csig certificate: $cert")
+
+            prefs.csigCerts = sequence {
+                yieldAll(allCerts.asSequence().filter { !it.second }.map { it.first })
+                yield(cert)
+            }.toSet()
+
+            loadCerts()
+        }
+    }
+
+    fun removeCsigCert(index: Int) {
+        val allCerts = _certs.value
+        val cert = allCerts[index].first
+        require(!allCerts[index].second) { "Tried to delete system certificate at $index: $cert" }
+
+        Log.d(TAG, "Removing user csig certificate: $cert")
+
+        prefs.csigCerts = allCerts
+            .asSequence()
+            .filterIndexed { i, _ -> i != index }
+            .map { it.first }
+            .toSet()
+
+        loadCerts()
     }
 
     fun refreshBootloaderStatus() {
@@ -76,5 +141,10 @@ class SettingsViewModel : ViewModel() {
 
     companion object {
         private val TAG = SettingsViewModel::class.java.simpleName
+
+        private val certCompare = compareBy<X509Certificate>(
+            { it.subjectDN.name },
+            { it.serialNumber },
+        )
     }
 }

--- a/app/src/main/java/com/chiller3/custota/updater/OtaPaths.kt
+++ b/app/src/main/java/com/chiller3/custota/updater/OtaPaths.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -35,9 +35,9 @@ object OtaPaths {
     const val METADATA_NAME = "metadata.pb"
 
     /** Parse X509 certificates from [OTACERTS_ZIP]. */
-    val otaCerts: List<X509Certificate>
+    val otaCerts: Set<X509Certificate>
         get() {
-            val result = mutableListOf<X509Certificate>()
+            val result = mutableSetOf<X509Certificate>()
             val factory = CertificateFactory.getInstance("X.509")
 
             ZipFile(OTACERTS_ZIP).use { zip ->

--- a/app/src/main/res/values-vi/values.xml
+++ b/app/src/main/res/values-vi/values.xml
@@ -15,7 +15,7 @@
     <!-- General preferences -->
     <string name="pref_check_for_updates_name">Kiểm tra cập nhật OTA</string>
     <string name="pref_check_for_updates_desc">Đặt lịch kiểm tra cập nhật OTA.</string>
-    <string name="pref_certificate_name">Chứng chỉ %1$s</string>
+    <string name="pref_certificate_name">Chứng chỉ %1$s (%2$s)</string>
     <string name="pref_certificate_desc_subject">Chủ đề: %1$s</string>
     <string name="pref_certificate_desc_serial">Số sê-ri: %1$s</string>
     <string name="pref_certificate_desc_type">Loại: %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+    SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
     SPDX-License-Identifier: GPL-3.0-only
 -->
 <resources>
@@ -17,7 +17,7 @@
     <string name="pref_check_for_updates_desc">Schedule a check for new OTA updates.</string>
     <string name="pref_ota_source_name">OTA installation source</string>
     <string name="pref_ota_source_none">No installation source set.</string>
-    <string name="pref_certificate_name">Certificate %1$s</string>
+    <string name="pref_certificate_name">Certificate %1$s (%2$s)</string>
     <string name="pref_certificate_desc_subject">Subject: %1$s</string>
     <string name="pref_certificate_desc_serial">Serial: %1$s</string>
     <string name="pref_certificate_desc_type">Type: %1$s</string>
@@ -61,6 +61,8 @@
     <string name="pref_allow_reinstall_desc">If the latest OTA matches the current OS fingerprint, treat it as an update. This may cause continuous reinstalls if automatic updates are enabled.</string>
     <string name="pref_revert_completed_name">Revert completed update</string>
     <string name="pref_revert_completed_desc">This is only possible after an update completes, but before rebooting. This is meant for debugging purposes only.</string>
+    <string name="pref_install_csig_cert_name">Install csig certificate</string>
+    <string name="pref_install_csig_cert_desc">The certificate is only used for verifying <tt>.csig</tt> files. This is not necessary when the certificate exists in the system\'s <tt>otacerts.zip</tt>. Long press the certificate to remove it.</string>
 
     <!-- Dialogs -->
     <string name="dialog_ota_source_title">@string/pref_ota_source_name</string>

--- a/app/src/main/res/xml/preferences_root.xml
+++ b/app/src/main/res/xml/preferences_root.xml
@@ -139,5 +139,12 @@
             app:title="@string/pref_revert_completed_name"
             app:summary="@string/pref_revert_completed_desc"
             app:iconSpaceReserved="false" />
+
+        <Preference
+            app:key="install_csig_cert"
+            app:persistent="false"
+            app:title="@string/pref_install_csig_cert_name"
+            app:summary="@string/pref_install_csig_cert_desc"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
This is useful when the csig is signed by a different key than the OTA and installing the certificate in `/system/etc/security/otacerts.zip` isn't desired.

Issue: #47