### PR TITLE
Clear package manager cache entries on boot

### DIFF
--- a/app/module/boot_common.sh
+++ b/app/module/boot_common.sh
@@ -16,12 +16,23 @@ module_prop() {
     grep "^${1}=" "${mod_dir}/module.prop" | cut -d= -f2
 }
 
+run_cli_apk() {
+    CLASSPATH="${cli_apk}" app_process / "${@}" &
+    pid=${!}
+    wait "${pid}"
+    echo "Exit status: ${?}"
+    echo "Logcat:"
+    logcat -d --pid "${pid}"
+}
+
 app_id=$(module_prop id)
 app_version=$(module_prop version)
+cli_apk=$(echo "${mod_dir}"/system/priv-app/"${app_id}"/app-*.apk)
 
 header Environment
 echo "Timestamp: $(date)"
 echo "Script: ${0}"
 echo "App ID: ${app_id}"
 echo "App version: ${app_version}"
+echo "CLI APK: ${cli_apk}"
 echo "UID/GID/Context: $(id)"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -45,3 +45,8 @@
 -keep class android.ota.OtaPackageMetadata* {
     *;
 }
+
+# Keep standalone CLI utilities
+-keep class com.chiller3.custota.standalone.* {
+    *;
+}

--- a/app/src/main/java/com/chiller3/custota/standalone/ClearPackageManagerCaches.kt
+++ b/app/src/main/java/com/chiller3/custota/standalone/ClearPackageManagerCaches.kt
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Based on BCR code.
+ */
+
+@file:Suppress("SameParameterValue")
+
+package com.chiller3.custota.standalone
+
+import com.chiller3.custota.BuildConfig
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.deleteIfExists
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.readBytes
+import kotlin.io.path.walk
+import kotlin.system.exitProcess
+
+private val PACKAGE_CACHE_DIR = Paths.get("/data/system/package_cache")
+
+private var dryRun = false
+
+private fun delete(path: Path) {
+    if (dryRun) {
+        println("Would have deleted: $path")
+    } else {
+        println("Deleting: $path")
+        path.deleteIfExists()
+    }
+}
+
+private fun ByteArray.indexOfSubarray(needle: ByteArray, start: Int = 0): Int {
+    require(start >= 0) { "start must be non-negative" }
+
+    if (needle.isEmpty()) {
+        return 0
+    }
+
+    outer@ for (i in 0 until size - needle.size + 1) {
+        for (j in needle.indices) {
+            if (this[i + j] != needle[j]) {
+                continue@outer
+            }
+        }
+        return i
+    }
+
+    return -1
+}
+
+@OptIn(ExperimentalPathApi::class)
+private fun clearPackageManagerCache(appId: String): Boolean {
+    // The current implementation of the package cache uses PackageImpl.writeToParcel(), which
+    // serializes the cache entry to the file as a Parcel. The current Parcel implementation stores
+    // string values as null-terminated little-endian UTF-16. One of the string values stored is
+    // manifestPackageName, which we can match on.
+    //
+    // This is a unique enough search that there should never be a false positive, but even if there
+    // is, the package manager will just repopulate the cache.
+    val needle = "\u0000$appId\u0000".toByteArray(Charsets.UTF_16LE)
+    var ret = true
+
+    for (path in PACKAGE_CACHE_DIR.walk()) {
+        if (!path.isRegularFile()) {
+            continue
+        }
+
+        try {
+            // Not the most efficient, but these are tiny files that Android is later going to read
+            // entirely into memory anyway
+            if (path.readBytes().indexOfSubarray(needle) >= 0) {
+                delete(path)
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+            ret = false
+        }
+    }
+
+    return ret
+}
+
+private fun mainInternal() {
+    clearPackageManagerCache(BuildConfig.APPLICATION_ID)
+}
+
+fun main(args: Array<String>) {
+    if ("--dry-run" in args) {
+        dryRun = true
+    }
+
+    try {
+        mainInternal()
+    } catch (e: Exception) {
+        System.err.println("Failed to clear caches")
+        e.printStackTrace()
+        exitProcess(1)
+    }
+}


### PR DESCRIPTION
Some devices don't set the system time properly during boot, causing Android's package manager to fail to invalidate cached package info. Work around this by forcibly deleting the relevant cache files.

Issue: #51
See: chenxiaolong/BCR#323