### PR TITLE
custota-tool: Add support for cross-compiling to Android

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
       # https://github.com/rust-lang/rust/issues/78210
       RUSTFLAGS: -C strip=symbols -C target-feature=+crt-static
       TARGETS: ${{ join(matrix.artifact.targets, ' ') || matrix.artifact.name }}
+      ANDROID_API: ${{ matrix.artifact.android_api }}
     strategy:
       fail-fast: false
       matrix:
@@ -50,12 +51,25 @@ jobs:
               - aarch64-apple-darwin
               - x86_64-apple-darwin
             combine: lipo
+          # ubuntu-latest is not 24.04 yet and 22.04's qemu-user-static segfaults.
+          - os: ubuntu-24.04
+            name: aarch64-linux-android31
+            targets:
+              - aarch64-linux-android
+            android_api: '31'
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
           # For git describe
           fetch-depth: 0
+
+      - name: Install cargo-android
+        shell: bash
+        run: |
+          cargo install \
+              --git https://github.com/chenxiaolong/cargo-android \
+              --tag v0.1.1
 
       - name: Get version
         id: get_version
@@ -83,7 +97,8 @@ jobs:
         working-directory: custota-tool
         run: |
           for target in ${TARGETS}; do
-              cargo clippy --release --features static \
+              cargo android \
+                  clippy --release --features static \
                   --target "${target}"
           done
 
@@ -96,7 +111,8 @@ jobs:
         working-directory: custota-tool
         run: |
           for target in ${TARGETS}; do
-              cargo build --release --features static \
+              cargo android \
+                  build --release --features static \
                   --target "${target}"
           done
 

--- a/README.md
+++ b/README.md
@@ -370,6 +370,14 @@ The output binary is written to `target/release/custota-tool`.
 
 Debug builds work too, but they will run significantly slower (in the sha256 computations) due to compiler optimizations being turned off.
 
+### Android cross-compilation
+
+To cross-compile for Android, install [cargo-android](https://github.com/chenxiaolong/cargo-android) and use the `cargo android` wrapper. To make a release build for aarch64, run:
+
+```bash
+cargo android build --release --target aarch64-linux-android
+```
+
 ## Contributing
 
 Bug fix and translation pull requests are welcome and much appreciated!


### PR DESCRIPTION
The precompiled binaries are compiled for aarch64 API 31, which should work for every device that avbroot supports.

Issue: #60