### PR TITLE
UpdaterJob: Add support for falling back to active network

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,6 +97,8 @@
     <string name="notification_update_ota_cancelled">OTA update process was cancelled</string>
     <string name="notification_update_ota_reverted">Successfully reverted OTA update</string>
     <string name="notification_update_ota_failed">Failed to install OTA update</string>
+    <string name="notification_null_network_fallback">Background job network restrictions are broken in this build of Android. Disable the Require Unmetered Network option to allow using any active network.</string>
+    <string name="notification_null_network_unavailable">Background job network restrictions are broken in this build of Android. The background job ran despite there being no active network connection.</string>
     <string name="notification_action_install">Install</string>
     <string name="notification_action_pause">Pause</string>
     <string name="notification_action_resume">Resume</string>


### PR DESCRIPTION
It appears on that for some folks running the Android 15 beta, Android's job scheduler implementation is broken and returns a null Network instance. This commit adds support for falling back to the currently active network if the Require Unmetered Network option is turned off. Otherwise, the only thing we can do is show a notification to tell the user to turn that option off.

Closes: #68