### PR TITLE
custota-selinux: Avoid truncating /sys/fs/selinux/load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,8 +1550,8 @@ dependencies = [
 
 [[package]]
 name = "sepatch"
-version = "0.2.0"
-source = "git+https://github.com/chenxiaolong/sepatch?tag=v0.2.0#1af38bbd833963c868cc2d64dacfec2ff8a94c03"
+version = "0.3.0"
+source = "git+https://github.com/chenxiaolong/sepatch?tag=v0.3.0#11b95d8b161a2981d4bd4c00658322a451f56210"
 dependencies = [
  "bindgen",
  "cc",

--- a/custota-selinux/Cargo.toml
+++ b/custota-selinux/Cargo.toml
@@ -11,4 +11,4 @@ clap = { version = "4.5.9", features = ["derive"] }
 
 [dependencies.sepatch]
 git = "https://github.com/chenxiaolong/sepatch"
-tag = "v0.2.0"
+tag = "v0.3.0"


### PR DESCRIPTION
This causes the file modification timestamp to change, which some apps use to detect if the SELinux policy has been modified.

Closes: #72