### PR TITLE
Show notification for post-reboot cleanup process after OTA update

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Android's `update_engine` verifies OTA signatures against certificates contained
   * Needed to reboot the device when the user explicitly presses the reboot button in Custota's notification after an update is installed.
 * `RECEIVE_BOOT_COMPLETED` (**automatically granted at install time**)
   * Needed to schedule periodic update checks.
+  * Needed to show the OTA cleanup notification on the reboot following an OTA update.
 * `WAKE_LOCK` (**automatically granted at install time**)
   * Needed to keep the CPU awake while an update is being installed.
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+    SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
     SPDX-License-Identifier: GPL-3.0-only
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
@@ -46,6 +46,15 @@
             android:name=".updater.UpdaterService"
             android:foregroundServiceType="specialUse"
             android:exported="false" />
+
+        <receiver
+            android:name=".updater.UpdaterBootReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
 
         <activity
             android:name=".settings.SettingsActivity"

--- a/app/src/main/java/com/chiller3/custota/updater/UpdateEngineError.kt
+++ b/app/src/main/java/com/chiller3/custota/updater/UpdateEngineError.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -72,6 +72,9 @@ object UpdateEngineError {
     const val DEVICE_CORRUPTED = 61
     const val PACKAGE_EXCLUDED_FROM_UPDATE = 62
     const val POST_INSTALL_MOUNT_ERROR = 63
+    const val OVERLAYFS_ENABLED_ERROR = 64
+    const val UPDATE_PROCESSING = 65
+    const val UPDATE_ALREADY_INSTALLED = 66
 
     private val STRINGS = arrayOf(
         UpdateEngineError::SUCCESS.name,
@@ -138,6 +141,9 @@ object UpdateEngineError {
         UpdateEngineError::DEVICE_CORRUPTED.name,
         UpdateEngineError::PACKAGE_EXCLUDED_FROM_UPDATE.name,
         UpdateEngineError::POST_INSTALL_MOUNT_ERROR.name,
+        UpdateEngineError::OVERLAYFS_ENABLED_ERROR.name,
+        UpdateEngineError::UPDATE_PROCESSING.name,
+        UpdateEngineError::UPDATE_ALREADY_INSTALLED,
     )
 
     /**

--- a/app/src/main/java/com/chiller3/custota/updater/UpdateEngineStatus.kt
+++ b/app/src/main/java/com/chiller3/custota/updater/UpdateEngineStatus.kt
@@ -1,11 +1,11 @@
 /*
- * SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
 package com.chiller3.custota.updater
 
-/** Must match AOSP's system/update_engine/common/error_code.h. */
+/** Must match AOSP's system/update_engine/client_library/include/update_engine/update_status.h. */
 @Suppress("MemberVisibilityCanBePrivate")
 object UpdateEngineStatus {
     const val IDLE = 0
@@ -18,6 +18,8 @@ object UpdateEngineStatus {
     const val REPORTING_ERROR_EVENT = 7
     const val ATTEMPTING_ROLLBACK = 8
     const val DISABLED = 9
+    const val NEED_PERMISSION_TO_UPDATE = 10
+    const val CLEANUP_PREVIOUS_UPDATE = 11
 
     private val STRINGS = arrayOf(
         UpdateEngineStatus::IDLE.name,
@@ -30,6 +32,8 @@ object UpdateEngineStatus {
         UpdateEngineStatus::REPORTING_ERROR_EVENT.name,
         UpdateEngineStatus::ATTEMPTING_ROLLBACK.name,
         UpdateEngineStatus::DISABLED.name,
+        UpdateEngineStatus::NEED_PERMISSION_TO_UPDATE.name,
+        UpdateEngineStatus::CLEANUP_PREVIOUS_UPDATE.name,
     )
 
     init {

--- a/app/src/main/java/com/chiller3/custota/updater/UpdaterBootReceiver.kt
+++ b/app/src/main/java/com/chiller3/custota/updater/UpdaterBootReceiver.kt
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.custota.updater
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class UpdaterBootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent?) {
+        if (intent?.action != Intent.ACTION_BOOT_COMPLETED) {
+            return
+        }
+
+        // This will monitor the cleanup process on the reboot immediately following an OTA.
+        UpdaterJob.scheduleImmediate(context, UpdaterThread.Action.CHECK)
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,7 @@
     <string name="notification_state_install">Installing OTA update</string>
     <string name="notification_state_verify">Verifying OTA update</string>
     <string name="notification_state_finalize">Finalizing OTA update</string>
+    <string name="notification_state_cleanup">Cleaning up OTA update</string>
     <string name="notification_update_init_failed">Failed to initialize OTA updater</string>
     <string name="notification_update_ota_available">OTA update is available</string>
     <string name="notification_update_ota_unnecessary">OS is already up to date</string>


### PR DESCRIPTION
On virtual A/B devices, after an OTA is installed and the device is rebooted, the system will merge the new data from the copy-on-write volumes to the actual partitions. This process takes a few minutes and most users aren't aware that it is happening.

It also causes some weird behavior with Custota. If the user tried to check for updates during this process, the notification would say the updater is initializing for a few minutes and then report that the OTA was successfully installed (again). Let's fix this by showing what is actually going on.

This commit also fixes a couple other notification issues:

* The `UpdaterThread.ProgressType.INIT` state has been removed since it races with `onStatusUpdate()` and sometimes causes the initialization message to be shown longer than necessary (until the next progress update). It is not necessary anyway since `UpdaterService` shows the initialization message when it hasn't received any state yet.
* Only show the pause, resume, and cancel notification actions during the `UPDATE`, `VERIFY`, and `FINALIZE` states because those are the only states where they would work anyway.