### PR TITLE
Show indeterminate progress bar when progress is at 0 percent

### DIFF
--- a/app/src/main/java/com/chiller3/custota/Notifications.kt
+++ b/app/src/main/java/com/chiller3/custota/Notifications.kt
@@ -111,7 +111,10 @@ class Notifications(
             setOnlyAlertOnce(true)
 
             if (progressCurrent != null && progressMax != null) {
-                if (progressMax <= 0) {
+                // We also show an indeterminate progress bar when the current progress is 0 because
+                // some phases, like the finalization and cleanup phases, don't always report their
+                // actual progress.
+                if (progressMax <= 0 || progressCurrent == 0) {
                     setProgress(0, 0, true)
                 } else {
                     setProgress(progressMax, progressCurrent, false)


### PR DESCRIPTION
The only phases that report progress are the update and verification phases. The finalization and cleanup phases don't report their progress. Let's show an indeterminate progress bar to not mislead the user with a perpetually non-increasing progress bar.