### PR TITLE
UpdaterThread: Add new MONITOR action

### DIFF
--- a/app/src/main/java/com/chiller3/custota/updater/UpdaterBootReceiver.kt
+++ b/app/src/main/java/com/chiller3/custota/updater/UpdaterBootReceiver.kt
@@ -16,6 +16,6 @@ class UpdaterBootReceiver : BroadcastReceiver() {
         }
 
         // This will monitor the cleanup process on the reboot immediately following an OTA.
-        UpdaterJob.scheduleImmediate(context, UpdaterThread.Action.CHECK)
+        UpdaterJob.scheduleImmediate(context, UpdaterThread.Action.MONITOR)
     }
 }

--- a/app/src/main/java/com/chiller3/custota/updater/UpdaterService.kt
+++ b/app/src/main/java/com/chiller3/custota/updater/UpdaterService.kt
@@ -218,7 +218,7 @@ class UpdaterService : Service(), UpdaterThread.UpdaterThreadListener {
         val showReboot: Boolean
 
         when (result) {
-            is UpdaterThread.UpdateCleanedUp -> {
+            is UpdaterThread.NothingToMonitor, is UpdaterThread.UpdateCleanedUp -> {
                 // No need to bug the user about this since it's automatic and not directly caused
                 // in response to a user action.
                 return


### PR DESCRIPTION
We only want to monitor update_engine's status immediate after boot so that we can show a notification during the snapuserd merge operation. We don't want to annoy the user with update check notifications.