### PR TITLE
ci.yml: Use target name in Rust cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,7 @@ jobs:
               - aarch64-apple-darwin
               - x86_64-apple-darwin
             combine: lipo
-          # ubuntu-latest is not 24.04 yet and 22.04's qemu-user-static segfaults.
-          - os: ubuntu-24.04
+          - os: ubuntu-latest
             name: aarch64-linux-android31
             targets:
               - aarch64-linux-android
@@ -118,6 +117,8 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.artifact.name }}
 
       - name: Clippy
         shell: bash


### PR DESCRIPTION
Otherwise, the x86_64-unknown-linux-gnu build running on Ubuntu 22.04 can use the cache from the aarch64-linux-android31 build that originally ran on Ubuntu 24.04. This fails due to some cached components having been compiled against a newer version of glibc.

This commit also stops using ubuntu-24.04 because qemu-user-static isn't needed. That was a leftover from copying things from avbroot.