### PR TITLE
post-fs-data: Mount cacerts ourselves and unmount shadowed mount points

### DIFF
--- a/custota-tool/system-ca-certs/post-fs-data.sh
+++ b/custota-tool/system-ca-certs/post-fs-data.sh
@@ -2,6 +2,12 @@ exec >/data/local/tmp/system-ca-certs.log 2>&1
 set -eux
 
 mod_dir=${0%/*}
+
+module_prop() {
+    grep "^${1}=" "${mod_dir}/module.prop" | cut -d= -f2
+}
+
+module_id=$(module_prop id)
 apex_dir=/apex/com.android.conscrypt/cacerts
 system_dir=/system/etc/security/cacerts
 mnt_base=${mod_dir}/mnt
@@ -19,7 +25,8 @@ for cert_dir in "${apex_dir}" "${system_dir}"; do
     let mnt_index+=1
 
     mkdir "${mnt_dir}"
-    mount -t tmpfs tmpfs "${mnt_dir}"
+    nsenter --mount=/proc/1/ns/mnt -- \
+        mount -t tmpfs "${module_id}" "${mnt_dir}"
 
     cp -r "${cert_dir}/." "${mnt_dir}"
     cp -r "${mod_dir}/cacerts/." "${mnt_dir}"
@@ -27,6 +34,10 @@ for cert_dir in "${apex_dir}" "${system_dir}"; do
     context=$(ls -Zd "${cert_dir}" | awk '{print $1}')
     chcon -R "${context}" "${mnt_dir}"
 
+    while mountpoint -q "${cert_dir}"; do
+        umount -l "${cert_dir}"
+    done
+
     nsenter --mount=/proc/1/ns/mnt -- \
-        mount -o bind "${mnt_dir}" "${cert_dir}"
+        mount -o ro,bind "${mnt_dir}" "${cert_dir}"
 done


### PR DESCRIPTION
During early boot, Magisk first runs all `post-fs-data.sh` scripts and then it mounts each module's `<module dir>/system` overrides. This breaks support for using custom CA certs via the system-ca-certs module if it just so happens that filesystem ordering causes Custota to be loaded before system-ca-certs. Custota's gathering of the system certs would run before system-ca-certs, but Magisk's mounting of the resulting files would run after.

To make things easier to troubleshoot, both modules now use the module ID as the arbitrary string for the source device for the mount instead of just `tmpfs`.

This commit additionally fixes another issue with the upcoming version of Magisk. Magisk appears to "clean up" shadowed mount points now instead of just keeping them around and relying on Linux's last mount point wins behavior. However, it seems to keep the first mount around instead of the last mount, breaking the usual assumptions. To avoid this, both modules will now unmount all previous mounts on the cacerts directories before creating the new bind mounts.

Fixes: #87