### PR TITLE
DocumentFileExtensions: Fix Cursor resource leak

### DIFF
--- a/app/src/main/java/com/chiller3/custota/extension/CursorExtensions.kt
+++ b/app/src/main/java/com/chiller3/custota/extension/CursorExtensions.kt
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.custota.extension
+
+import android.database.Cursor
+
+fun Cursor.asSequence() = generateSequence(seed = takeIf { it.moveToFirst() }) {
+    takeIf { it.moveToNext() }
+}

--- a/app/src/main/java/com/chiller3/custota/extension/DocumentFileExtensions.kt
+++ b/app/src/main/java/com/chiller3/custota/extension/DocumentFileExtensions.kt
@@ -8,10 +8,12 @@ package com.chiller3.custota.extension
 
 import android.content.ContentResolver
 import android.content.Context
+import android.database.Cursor
 import android.net.Uri
 import android.provider.DocumentsContract
 import android.util.Log
 import androidx.documentfile.provider.DocumentFile
+import java.io.IOException
 
 private const val TAG = "DocumentFileExtensions"
 
@@ -29,14 +31,15 @@ private val DocumentFile.context: Context?
 private val DocumentFile.isTree: Boolean
     get() = uri.scheme == ContentResolver.SCHEME_CONTENT && DocumentsContract.isTreeUri(uri)
 
-private fun DocumentFile.iterChildrenWithColumns(extraColumns: Array<String>) = iterator {
+private fun <R> DocumentFile.withChildrenWithColumns(
+    columns: Array<String>,
+    block: (Cursor, Sequence<Pair<DocumentFile, Cursor>>) -> R,
+): R {
     require(isTree) { "Not a tree URI" }
-
-    val file = this@iterChildrenWithColumns
 
     // These reflection calls access private fields, but everything is part of the
     // androidx.documentfile:documentfile dependency and we control the version of that.
-    val constructor = file.javaClass.getDeclaredConstructor(
+    val constructor = javaClass.getDeclaredConstructor(
         DocumentFile::class.java,
         Context::class.java,
         Uri::class.java,
@@ -44,23 +47,29 @@ private fun DocumentFile.iterChildrenWithColumns(extraColumns: Array<String>) = 
         isAccessible = true
     }
 
-    context!!.contentResolver.query(
+    val cursor = context!!.contentResolver.query(
         DocumentsContract.buildChildDocumentsUriUsingTree(
             uri,
             DocumentsContract.getDocumentId(uri),
         ),
-        arrayOf(DocumentsContract.Document.COLUMN_DOCUMENT_ID) + extraColumns,
+        columns + arrayOf(DocumentsContract.Document.COLUMN_DOCUMENT_ID),
         null, null, null,
-    )?.use {
-        while (it.moveToNext()) {
+    ) ?: throw IOException("Query returned null cursor: $uri: $columns")
+
+    return cursor.use {
+        val indexDocumentId =
+            cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_DOCUMENT_ID)
+
+        block(cursor, cursor.asSequence().map {
+            val documentId = it.getString(indexDocumentId)
             val child: DocumentFile = constructor.newInstance(
-                file,
+                this,
                 context,
-                DocumentsContract.buildDocumentUriUsingTree(uri, it.getString(0)),
+                DocumentsContract.buildDocumentUriUsingTree(uri, documentId),
             )
 
-            yield(Pair(child, it))
-        }
+            Pair(child, it)
+        })
     }
 }
 
@@ -77,16 +86,17 @@ fun DocumentFile.findFileFast(displayName: String): DocumentFile? {
         return findFile(displayName)
     }
 
-    try {
-        return iterChildrenWithColumns(arrayOf(DocumentsContract.Document.COLUMN_DISPLAY_NAME))
-            .asSequence()
-            .find { it.second.getString(1) == displayName }
-            ?.first
+    return try {
+        withChildrenWithColumns(arrayOf(DocumentsContract.Document.COLUMN_DISPLAY_NAME)) { c, sequence ->
+            val indexDisplayName =
+                c.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_DISPLAY_NAME)
+
+            sequence.find { it.second.getString(indexDisplayName) == displayName }?.first
+        }
     } catch (e: Exception) {
         Log.w(TAG, "Failed to query tree URI", e)
+        null
     }
-
-    return null
 }
 
 /** Like [DocumentFile.findFileFast], but accepts nested paths. */


### PR DESCRIPTION
The original idea was fundamentally not workable. Nothing would cause the `use { ... }` block to end immediately after we stop consuming the iterator. I'm too used to languages with RAII.