### PR TITLE
Notifications: Avoid overriding expanded notification text

### DIFF
--- a/app/src/main/java/com/chiller3/custota/Notifications.kt
+++ b/app/src/main/java/com/chiller3/custota/Notifications.kt
@@ -103,7 +103,7 @@ class Notifications(
             setContentTitle(context.getText(titleResId))
             if (message != null) {
                 setContentText(message)
-                style = Notification.BigTextStyle().bigText(message)
+                style = Notification.BigTextStyle()
             }
             setSmallIcon(iconResId)
             setContentIntent(pendingIntent)


### PR DESCRIPTION
We don't use a different expanded notification message, so the default behavior is sufficient.