### PR TITLE
custota-tool: Add support for generating version 1 csig files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,6 +571,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
+ "serde_repr",
  "sha2",
  "x509-cert",
  "zip",
@@ -1643,6 +1644,17 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
 ]
 
 [[package]]

--- a/custota-tool/Cargo.toml
+++ b/custota-tool/Cargo.toml
@@ -19,6 +19,7 @@ ring = "0.17.0"
 rsa = { version = "0.9.2", features = ["sha2"] }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"
+serde_repr = "0.1.19"
 sha2 = { version = "0.10.7", features = ["std"] }
 x509-cert = "0.2.4"
 


### PR DESCRIPTION
This way, users don't need to downgrade to an older version just to generate the files.

Issue: #94