### PR TITLE
Allow unknown keys when parsing csig files and update JSON files

### DIFF
--- a/app/src/main/java/com/chiller3/custota/updater/UpdaterThread.kt
+++ b/app/src/main/java/com/chiller3/custota/updater/UpdaterThread.kt
@@ -228,7 +228,7 @@ class UpdaterThread(
             openUrl(URL(uri.toString())).inputStream
         }
 
-        val updateInfo: UpdateInfo = stream.use { Json.decodeFromStream(it) }
+        val updateInfo: UpdateInfo = stream.use { jsonFormat.decodeFromStream(it) }
         Log.d(TAG, "Update info: $updateInfo")
 
         if (updateInfo.version != 2) {
@@ -387,7 +387,7 @@ class UpdaterThread(
         Log.d(TAG, "csig is signed by: $csigCert")
 
         val csigInfoRaw = String(csigCms.signedContent.content as ByteArray)
-        val csigInfo: CsigInfo = Json.decodeFromString(csigInfoRaw)
+        val csigInfo: CsigInfo = jsonFormat.decodeFromString(csigInfoRaw)
         Log.d(TAG, "csig info: $csigInfo")
 
         // The only difference in version 2 is the introduction of the vbmeta_digest field.
@@ -892,6 +892,8 @@ class UpdaterThread(
 
         private const val PROP_SECURITY_PATCH = "ro.build.version.security_patch"
         private const val PROP_VBMETA_DIGEST = "ro.boot.vbmeta.digest"
+
+        private val jsonFormat = Json { ignoreUnknownKeys = true }
 
         /**
          * Get the OS security patch level.


### PR DESCRIPTION
The versioning of the two file formats unfortunately didn't work out as well as I hoped. To support older versions of Custota, the server would need to keep serving the old file formats without any good upgrade path besides doing a hard cutover at some point.

Instead, let's try taking a page from the protobuf book and just make version 2 extensible by adding new fields. Custota from now on will just ignore fields it does not understand. I'll plan on having custota-tool output all fields forever for future backwards compatibility.

Issue: #94