### PR TITLE
post-fs-data.sh: Combine seapp snippets from all modules to produce full file

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -368,6 +368,24 @@ android.applicationVariants.all {
         }
     }
 
+    val seappContexts = tasks.register("seappContexts${capitalized}") {
+        inputs.property("variant.applicationId", variant.applicationId)
+
+        val outputFile = variantDir.map { it.file("plat_seapp_contexts") }
+        outputs.file(outputFile)
+
+        doLast {
+            outputFile.get().asFile.writeText(listOf(
+                "user=_app",
+                "isPrivApp=true",
+                "name=${variant.applicationId}",
+                "domain=msd_app",
+                "type=app_data_file",
+                "levelFrom=all",
+            ).joinToString(" "))
+        }
+    }
+
     tasks.register<Zip>("zip${capitalized}") {
         inputs.property("rootProject.name", rootProject.name)
         inputs.property("variant.applicationId", variant.applicationId)
@@ -391,6 +409,7 @@ android.applicationVariants.all {
         from(configXml.map { it.outputs }) {
             into("system/etc/sysconfig")
         }
+        from(seappContexts.map { it.outputs })
         from(variant.outputs.map { it.outputFile }) {
             into("system/priv-app/${variant.applicationId}")
         }

--- a/app/module/post-fs-data.sh
+++ b/app/module/post-fs-data.sh
@@ -22,31 +22,22 @@ header Creating custota_app domain
 
 "${mod_dir}"/custota-selinux."$(getprop ro.product.cpu.abi)" -ST
 
+# Android's SELinux implementation cannot load seapp_contexts files from a
+# directory, so the original file must be edited and multiple modules may want
+# to do so. Due to Magisk/KernelSU's behavior of running scripts for all modules
+# before mounting any files, each module that modifies this file needs to
+# produce the same output, so snippets from all modules are included.
+# Regardless of the module load order, all modules that include the following
+# command will produce the same output file, so it does not matter which one is
+# mounted last.
+
 header Updating seapp_contexts
 
-seapp_file=/system/etc/selinux/plat_seapp_contexts
-seapp_temp_dir=${mod_dir}/seapp_temp
-seapp_temp_file=${mod_dir}/seapp_temp/plat_seapp_contexts
-
-mkdir -p "${seapp_temp_dir}"
-
-nsenter --mount=/proc/1/ns/mnt -- \
-    mount -t tmpfs "${app_id}" "${seapp_temp_dir}"
-
-# Full path because Magisk runs this script in busybox's standalone ash mode and
-# we need Android's toybox version of cp.
-/system/bin/cp --preserve=a "${seapp_file}" "${seapp_temp_file}"
-
-cat >> "${seapp_temp_file}" << EOF
-user=_app isPrivApp=true name=${app_id} domain=custota_app type=app_data_file levelFrom=all
-EOF
-
-while has_mountpoint "${seapp_file}"; do
-    umount -l "${seapp_file}"
-done
-
-nsenter --mount=/proc/1/ns/mnt -- \
-    mount -o ro,bind "${seapp_temp_file}" "${seapp_file}"
+mkdir -p "${mod_dir}/system/etc/selinux"
+paste -s -d '\n' \
+    /system/etc/selinux/plat_seapp_contexts \
+    /data/adb/modules/*/plat_seapp_contexts \
+    > "${mod_dir}/system/etc/selinux/plat_seapp_contexts"
 
 # On some devices, the system time is set too late in the boot process. This,
 # for some reason, causes the package manager service to not update the package


### PR DESCRIPTION
This is more reliable and has better compatibility than trying to mount things ourselves. Any module that modifies plat_seapp_contents and includes the same command will produce the same output file, so the order that Magisk/KernelSU loads and mounts modules does not matter. Currently, MSD and Custota are the only two modules known to modify this file.

MSD version of this PR: https://github.com/chenxiaolong/MSD/pull/26