### PR TITLE
Only add network/battery restrictions to scheduled jobs when needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Custota is installed via a Magisk/KernelSU module so that it can run as a system
 
 Once the OTA server URL is configured, Custota will automatically check for updates periodically. The checks can be turned off completely or extended to automatically install the updates as well.
 
-To reduce battery usage, the scheduling of the update checks is controlled by Android. They run at most once every 6 hours and will not run at all if the `Require unmetered network` or `Require sufficient battery level` conditions aren't met.
+To reduce battery usage, the timing of the periodic update checks is controlled by Android. They run at most once every 6 hours.
 
 ## OTA server
 

--- a/app/src/main/java/com/chiller3/custota/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/custota/settings/SettingsFragment.kt
@@ -342,7 +342,9 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClic
                 refreshCheckForUpdates()
                 refreshOtaSource()
             }
-            Preferences.PREF_UNMETERED_ONLY, Preferences.PREF_BATTERY_NOT_LOW -> {
+            Preferences.PREF_AUTOMATIC_INSTALL,
+            Preferences.PREF_UNMETERED_ONLY,
+            Preferences.PREF_BATTERY_NOT_LOW -> {
                 UpdaterJob.schedulePeriodic(requireContext(), true)
             }
         }

--- a/app/src/main/java/com/chiller3/custota/updater/UpdaterThread.kt
+++ b/app/src/main/java/com/chiller3/custota/updater/UpdaterThread.kt
@@ -821,7 +821,16 @@ class UpdaterThread(
         MONITOR,
         CHECK,
         INSTALL,
-        REVERT,
+        REVERT;
+
+        val requiresNetwork: Boolean
+            get() = this == CHECK || this == INSTALL
+
+        val performsLargeDownloads: Boolean
+            get() = this == INSTALL
+
+        val usesSignificantBattery: Boolean
+            get() = this == INSTALL
     }
 
     sealed interface Result {


### PR DESCRIPTION
The `REVERT` and `MONITOR` jobs now no longer require a network connection and the unmetered network restriction no longer applies to `CHECK` jobs. The battery restriction now only applies to the `INSTALL` job.

Fixes: #104