### PR TITLE
Improve workaround for Android 15 null network bug

### DIFF
--- a/app/src/main/java/com/chiller3/custota/updater/UpdaterService.kt
+++ b/app/src/main/java/com/chiller3/custota/updater/UpdaterService.kt
@@ -94,7 +94,7 @@ class UpdaterService : Service(), UpdaterThread.UpdaterThreadListener {
             // IntentCompat is required due to an Android 13 bug that's only fixed in 14+
             // https://issuetracker.google.com/issues/274185314
             val network = IntentCompat.getParcelableExtra(
-                intent, EXTRA_NETWORK, Network::class.java)!!
+                intent, EXTRA_NETWORK, Network::class.java)
             val action = IntentCompat.getParcelableExtra(
                 intent, EXTRA_ACTION, UpdaterThread.Action::class.java)!!
             val silent = intent.getBooleanExtra(EXTRA_SILENT, false)
@@ -359,7 +359,7 @@ class UpdaterService : Service(), UpdaterThread.UpdaterThreadListener {
 
         fun createStartIntent(
             context: Context,
-            network: Network,
+            network: Network?,
             action: UpdaterThread.Action,
             silent: Boolean,
         ) = Intent(context, UpdaterService::class.java).apply {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,8 +98,6 @@
     <string name="notification_update_ota_cancelled">OTA update process was cancelled</string>
     <string name="notification_update_ota_reverted">Successfully reverted OTA update</string>
     <string name="notification_update_ota_failed">Failed to install OTA update</string>
-    <string name="notification_null_network_fallback">Background job network restrictions are broken in this build of Android. Disable the Require Unmetered Network option to allow using any active network.</string>
-    <string name="notification_null_network_unavailable">Background job network restrictions are broken in this build of Android. The background job ran despite there being no active network connection.</string>
     <string name="notification_action_install">Install</string>
     <string name="notification_action_pause">Pause</string>
     <string name="notification_action_resume">Resume</string>


### PR DESCRIPTION
We'll now try to query the capabilities of the active network in the fallback path so that the job will still run if the network satisfies the unmetered network requirement.

Since the fallback path (querying the active network) is no longer limited compared to the normal path (JobScheduler providing a valid network), the notification telling users about the Android 15 bug has been removed.