### PR TITLE
Add custota-tool show-csig subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,12 +242,16 @@ Although it's never possible for a `payload.bin` signed by an untrusted key to b
 The actual csig file is a DER-encoded CMS signature containing the JSON structure above in its encapsulated data. To display the encapsulated data, run:
 
 ```bash
+custota-tool show-csig -i <csig file> -r
+# Or with openssl:
 openssl cms -verify -in <csig file> -inform DER -binary -noverify
 ```
 
 To verify the csig's signature against a specific certificate, run:
 
 ```bash
+custota-tool show-csig -i <csig file> -c <cert file> -r
+# Or with openssl:
 openssl cms -verify -in <csig file> -inform DER -binary -CAfile <cert file>
 ```
 


### PR DESCRIPTION
This will display the contents of a csig file and optionally verify its signature. This way, openssl doesn't need to be manually installed on systems where it doesn't come preinstalled.