### PR TITLE
UpdaterJob: Cancel periodic job when automatic checks are disabled

### DIFF
--- a/app/src/main/java/com/chiller3/custota/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/custota/settings/SettingsFragment.kt
@@ -350,6 +350,7 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClic
                 refreshCheckForUpdates()
                 refreshOtaSource()
             }
+            Preferences.PREF_AUTOMATIC_CHECK,
             Preferences.PREF_AUTOMATIC_INSTALL,
             Preferences.PREF_UNMETERED_ONLY,
             Preferences.PREF_BATTERY_NOT_LOW -> {


### PR DESCRIPTION
This avoids needing to wake up the device for a no-op.