### PR TITLE
Don't require network access when OTA source is local

### DIFF
--- a/app/src/main/java/com/chiller3/custota/extension/UriExtensions.kt
+++ b/app/src/main/java/com/chiller3/custota/extension/UriExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2023 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2022-2025 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  * Based on BCR code.
  */
@@ -9,14 +9,20 @@ package com.chiller3.custota.extension
 import android.content.ContentResolver
 import android.net.Uri
 
-private const val DOCUMENTSUI_AUTHORITY = "com.android.externalstorage.documents"
+private const val EXTERNAL_STORAGE_AUTHORITY = "com.android.externalstorage.documents"
+
+private val LOCAL_PROVIDERS = arrayOf(
+    EXTERNAL_STORAGE_AUTHORITY,
+    "com.android.providers.downloads.documents",
+    "com.android.providers.media.documents",
+)
 
 val Uri.formattedString: String
     get() = when (scheme) {
         ContentResolver.SCHEME_FILE -> path!!
         ContentResolver.SCHEME_CONTENT -> {
             val prefix = when (authority) {
-                DOCUMENTSUI_AUTHORITY -> ""
+                EXTERNAL_STORAGE_AUTHORITY -> ""
                 // Include the authority to reduce ambiguity when this isn't a SAF URI provided by
                 // Android's local filesystem document provider
                 else -> "[$authority] "
@@ -35,3 +41,6 @@ val Uri.formattedString: String
         }
         else -> toString()
     }
+
+val Uri.isGuaranteedLocalFile: Boolean
+    get() = scheme == ContentResolver.SCHEME_CONTENT && LOCAL_PROVIDERS.contains(authority)

--- a/app/src/main/java/com/chiller3/custota/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/custota/settings/SettingsFragment.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2024 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2022-2025 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  * Based on BCR code.
  */
@@ -26,6 +26,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SwitchPreferenceCompat
 import androidx.preference.get
 import androidx.preference.size
 import androidx.recyclerview.widget.RecyclerView
@@ -35,6 +36,7 @@ import com.chiller3.custota.Preferences
 import com.chiller3.custota.R
 import com.chiller3.custota.dialog.OtaSourceDialogFragment
 import com.chiller3.custota.extension.formattedString
+import com.chiller3.custota.extension.isGuaranteedLocalFile
 import com.chiller3.custota.updater.OtaPaths
 import com.chiller3.custota.updater.UpdaterJob
 import com.chiller3.custota.updater.UpdaterThread
@@ -59,6 +61,7 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClic
     private lateinit var categoryDebug: PreferenceCategory
     private lateinit var prefCheckForUpdates: Preference
     private lateinit var prefOtaSource: LongClickablePreference
+    private lateinit var prefUnmeteredOnly: SwitchPreferenceCompat
     private lateinit var prefAndroidVersion: Preference
     private lateinit var prefSecurityPatchLevel: Preference
     private lateinit var prefFingerprint: Preference
@@ -135,6 +138,8 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClic
         prefOtaSource = findPreference(Preferences.PREF_OTA_SOURCE)!!
         prefOtaSource.onPreferenceClickListener = this
         prefOtaSource.onPreferenceLongClickListener = this
+
+        prefUnmeteredOnly = findPreference(Preferences.PREF_UNMETERED_ONLY)!!
 
         prefAndroidVersion = findPreference(Preferences.PREF_ANDROID_VERSION)!!
         prefAndroidVersion.summary = Build.VERSION.RELEASE
@@ -217,6 +222,8 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClic
     private fun refreshOtaSource() {
         prefOtaSource.summary = prefs.otaSource?.formattedString
             ?: getString(R.string.pref_ota_source_none)
+
+        prefUnmeteredOnly.isVisible = prefs.otaSource?.isGuaranteedLocalFile != true
     }
 
     private fun refreshVersion() {
@@ -349,6 +356,7 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClic
             Preferences.PREF_OTA_SOURCE -> {
                 refreshCheckForUpdates()
                 refreshOtaSource()
+                UpdaterJob.schedulePeriodic(requireContext(), true)
             }
             Preferences.PREF_AUTOMATIC_CHECK,
             Preferences.PREF_AUTOMATIC_INSTALL,

--- a/app/src/main/java/com/chiller3/custota/updater/UpdaterThread.kt
+++ b/app/src/main/java/com/chiller3/custota/updater/UpdaterThread.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2025 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -587,7 +587,9 @@ class UpdaterThread(
         Log.i(TAG, "Passing payload information to update_engine")
 
         val engineProperties = HashMap(payloadProperties).apply {
-            put("NETWORK_ID", network!!.networkHandle.toString())
+            network?.networkHandle?.let {
+                put("NETWORK_ID", it.toString())
+            }
             put("USER_AGENT", USER_AGENT_UPDATE_ENGINE)
 
             if (authorization != null) {


### PR DESCRIPTION
There's no reason Custota can't work fully offline when the OTA files exist in a local directory. Currently, this only works for Android's builtin local SAF providers: the external storage, media, and downloads providers. This covers every use case aside from selecting files from a third party local document provider. Unfortunately, there is no way to find out which SAF root a document belongs to or whether it has `FLAG_LOCAL_ONLY` set.