### PR TITLE
Add launcher shortcut to check for updates

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,6 +38,12 @@
         android:networkSecurityConfig="@xml/network_security_config"
         tools:ignore="UnusedAttribute">
 
+        <activity
+            android:name=".updater.UpdaterLauncherActivity"
+            android:exported="false"
+            android:taskAffinity=""
+            android:theme="@style/android:Theme.NoDisplay" />
+
         <service
             android:name=".updater.UpdaterJob"
             android:exported="false"

--- a/app/src/main/java/com/chiller3/custota/MainApplication.kt
+++ b/app/src/main/java/com/chiller3/custota/MainApplication.kt
@@ -7,8 +7,13 @@
 package com.chiller3.custota
 
 import android.app.Application
+import android.content.Intent
 import android.util.Log
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
 import com.chiller3.custota.updater.UpdaterJob
+import com.chiller3.custota.updater.UpdaterLauncherActivity
 import com.google.android.material.color.DynamicColors
 import java.io.File
 
@@ -42,6 +47,30 @@ class MainApplication : Application() {
         Notifications(this).updateChannels()
 
         UpdaterJob.schedulePeriodic(this, false)
+
+        updateShortcuts()
+    }
+
+    // We don't use static shortcuts because:
+    // * There's no way to substitute in the package name. ${applicationId} only works in the
+    //   manifest and custom resource definitions are evaluated to @ref/<resource ID>.
+    // * When anything breaks, the shortcuts are just silently missing with no error reporting.
+    private fun updateShortcuts() {
+        val icon = IconCompat.createWithResource(this, R.mipmap.ic_launcher)
+        val intent = Intent(this, UpdaterLauncherActivity::class.java).apply {
+            // Action is required, but value doesn't matter.
+            action = Intent.ACTION_MAIN
+        }
+        val shortcut = ShortcutInfoCompat.Builder(this, Preferences.PREF_CHECK_FOR_UPDATES)
+            .setShortLabel(getString(R.string.pref_check_for_updates_name))
+            .setIcon(icon)
+            .setIntent(intent)
+            .build()
+        val shortcuts = listOf(shortcut)
+
+        if (!ShortcutManagerCompat.setDynamicShortcuts(this, shortcuts)) {
+            Log.w(TAG, "Failed to update dynamic shortcuts")
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/chiller3/custota/updater/UpdaterLauncherActivity.kt
+++ b/app/src/main/java/com/chiller3/custota/updater/UpdaterLauncherActivity.kt
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.custota.updater
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import com.chiller3.custota.Permissions
+import com.chiller3.custota.settings.SettingsActivity
+
+class UpdaterLauncherActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        if (Permissions.haveRequired(this)) {
+            UpdaterJob.scheduleImmediate(this, UpdaterThread.Action.CHECK)
+        } else {
+            startActivity(Intent(this, SettingsActivity::class.java))
+        }
+
+        finish()
+    }
+}


### PR DESCRIPTION
This does the same thing as the normal manual check for updates option, except with fewer steps. There is a small UX issue where the home screen's shortcuts popup does not close because we launch a UI-less Activity to schedule the UpdaterJob. This is still better than having the UI flicker due to a non-UI-less Activity.