### PR TITLE
Allow OTAs with multiple fingerprints in postconditions

### DIFF
--- a/app/src/main/java/com/chiller3/custota/updater/UpdaterService.kt
+++ b/app/src/main/java/com/chiller3/custota/updater/UpdaterService.kt
@@ -228,7 +228,7 @@ class UpdaterService : Service(), UpdaterThread.UpdaterThreadListener {
                 // Only bug the user once while the notification is still shown
                 onlyAlertOnce = true
                 titleResId = R.string.notification_update_ota_available
-                message = result.fingerprint
+                message = result.fingerprints.joinToString("\n")
                 showInstall = true
                 showRetry = false
                 showReboot = false

--- a/custota-tool/src/main.rs
+++ b/custota-tool/src/main.rs
@@ -609,13 +609,16 @@ fn subcommand_gen_csig(args: &GenerateCsig, cancel_signal: &AtomicBool) -> Resul
         .postcondition
         .as_ref()
         .ok_or_else(|| anyhow!("Postconditions are missing"))?;
-    let fingerprint = postcondition
-        .build
-        .first()
-        .ok_or_else(|| anyhow!("Postconditions do not list a fingerprint"))?;
+
+    if postcondition.build.is_empty() {
+        bail!("Postconditions do not list any fingerprints");
+    }
 
     info!("Device name: {device_name}");
-    info!("Fingerprint: {fingerprint}");
+    info!("Fingerprints:");
+    for fingerprint in &postcondition.build {
+        info!("- {fingerprint}");
+    }
     info!("Security patch: {}", postcondition.security_patch_level);
 
     let pfs_raw = metadata


### PR DESCRIPTION
Some Nothing devices ship firmware for multiple regions in the same full OTA. These have the default fingerprint in `/system/build.prop` and then conditionally load region-specific propery files from `/odm/etc`. The OTA metadata lists all of these fingerprints in the postconditions.

Fixes: #129