### PR TITLE
Add support for direct boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Custota is installed via a Magisk/KernelSU module so that it can run as a system
 * Supports skipping optional post-install scripts to speed up updates
 * Never communicates with any server besides the configured OTA server
 * OTA updates safely continue running even if the app crashes or is uninstalled during the operation
+* Supports Direct Boot, allowing updates to install before the device is initially unlocked
 
 ## Limitations
 
@@ -46,9 +47,9 @@ Custota is installed via a Magisk/KernelSU module so that it can run as a system
 
 7. That's it!
 
-Once the OTA server URL is configured, Custota will automatically check for updates periodically. The checks can be turned off completely or extended to automatically install the updates as well.
+Once the OTA server URL is configured, Custota will automatically check for updates periodically. The checks can be turned off completely or extended to automatically install the updates as well. To reduce battery usage, the timing of the periodic update checks is controlled by Android. They run at most once every 6 hours.
 
-To reduce battery usage, the timing of the periodic update checks is controlled by Android. They run at most once every 6 hours.
+If OTAs are installed from an OTA server (instead of a local directory), then automatic checks and automatic installs will work even before the device is initially unlocked following a reboot.
 
 ## OTA server
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,20 +45,23 @@
 
         <service
             android:name=".updater.UpdaterJob"
+            android:directBootAware="true"
             android:exported="false"
             android:permission="android.permission.BIND_JOB_SERVICE" />
 
         <service
             android:name=".updater.UpdaterService"
+            android:directBootAware="true"
             android:foregroundServiceType="specialUse"
             android:exported="false" />
 
         <receiver
             android:name=".updater.UpdaterBootReceiver"
+            android:directBootAware="true"
             android:enabled="true"
             android:exported="true">
             <intent-filter>
-                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
 

--- a/app/src/main/java/com/chiller3/custota/Notifications.kt
+++ b/app/src/main/java/com/chiller3/custota/Notifications.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2023 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2022-2025 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  * Based on BCR code.
  */
@@ -159,6 +159,7 @@ class Notifications(
         @DrawableRes icon: Int,
         errorMsg: String?,
         actions: List<Pair<Int, Intent>>,
+        showOnLockScreen: Boolean,
     ) {
         val notification = Notification.Builder(context, channel).run {
             val text = buildString {
@@ -175,6 +176,9 @@ class Notifications(
             }
             setSmallIcon(icon)
             setOnlyAlertOnce(onlyAlertOnce)
+            if (showOnLockScreen) {
+                setVisibility(Notification.VISIBILITY_PUBLIC)
+            }
 
             for ((actionTextResId, actionIntent) in actions) {
                 val actionPendingIntent = PendingIntent.getService(

--- a/app/src/main/java/com/chiller3/custota/extension/UriExtensions.kt
+++ b/app/src/main/java/com/chiller3/custota/extension/UriExtensions.kt
@@ -43,4 +43,8 @@ val Uri.formattedString: String
     }
 
 val Uri.isGuaranteedLocalFile: Boolean
-    get() = scheme == ContentResolver.SCHEME_CONTENT && LOCAL_PROVIDERS.contains(authority)
+    get() = (scheme == ContentResolver.SCHEME_CONTENT && LOCAL_PROVIDERS.contains(authority))
+            || scheme == ContentResolver.SCHEME_FILE
+
+val Uri.isGuaranteedNetworkUri: Boolean
+    get() = scheme != ContentResolver.SCHEME_CONTENT && scheme != ContentResolver.SCHEME_FILE

--- a/app/src/main/java/com/chiller3/custota/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/custota/settings/SettingsFragment.kt
@@ -123,9 +123,10 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClic
     }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
-        setPreferencesFromResource(R.xml.preferences_root, rootKey)
-
         val context = requireContext()
+
+        preferenceManager.setStorageDeviceProtected()
+        setPreferencesFromResource(R.xml.preferences_root, rootKey)
 
         prefs = Preferences(context)
 

--- a/app/src/main/java/com/chiller3/custota/updater/UpdaterBootReceiver.kt
+++ b/app/src/main/java/com/chiller3/custota/updater/UpdaterBootReceiver.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2024-2025 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -11,7 +11,7 @@ import android.content.Intent
 
 class UpdaterBootReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent?) {
-        if (intent?.action != Intent.ACTION_BOOT_COMPLETED) {
+        if (intent?.action != Intent.ACTION_LOCKED_BOOT_COMPLETED) {
             return
         }
 


### PR DESCRIPTION
Automatic checks and automatic installs can now run before the user has unlocked the device following a reboot.

To avoid leaking information (eg. in case the device was stolen), only update check and success notifications are shown on the lock screen. The installation progress and failure messages are hidden until the device is unlocked. This also means an ongoing update cannot be paused or cancelled while the device is locked without physically interrupting the internet connection.

If the user uses a local directory or any other SAF provider as the source, then direct boot support is disabled. Local directories are not accessible and we can't know whether a SAF provider also supports direct boot.

The user's preferences will automatically be migrated from credential-protected storage to device-protected storage. If the app is downgraded, it will appear as if all settings were reset since the old preferences file will no longer exist.