### PR TITLE
Fix preferences migration improperly detecting BFU

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,15 @@
         android:networkSecurityConfig="@xml/network_security_config"
         tools:ignore="UnusedAttribute">
 
+        <receiver
+            android:name=".PostUnlockInitReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+
         <activity
             android:name=".updater.UpdaterLauncherActivity"
             android:exported="false"

--- a/app/src/main/java/com/chiller3/custota/MainApplication.kt
+++ b/app/src/main/java/com/chiller3/custota/MainApplication.kt
@@ -7,14 +7,7 @@
 package com.chiller3.custota
 
 import android.app.Application
-import android.content.Intent
-import android.os.UserManager
 import android.util.Log
-import androidx.core.content.pm.ShortcutInfoCompat
-import androidx.core.content.pm.ShortcutManagerCompat
-import androidx.core.graphics.drawable.IconCompat
-import com.chiller3.custota.updater.UpdaterJob
-import com.chiller3.custota.updater.UpdaterLauncherActivity
 import com.google.android.material.color.DynamicColors
 import java.io.File
 
@@ -45,47 +38,9 @@ class MainApplication : Application() {
         // Enable Material You colors
         DynamicColors.applyToActivitiesIfAvailable(this)
 
-        // Move preferences to device-protected storage for direct boot support.
-        Preferences.migrateToDeviceProtectedStorage(this)
-
-        Preferences(this).migrate()
-
         Notifications(this).updateChannels()
 
-        UpdaterJob.schedulePeriodic(this, false)
-
-        updateShortcuts()
-    }
-
-    // We don't use static shortcuts because:
-    // * There's no way to substitute in the package name. ${applicationId} only works in the
-    //   manifest and custom resource definitions are evaluated to @ref/<resource ID>.
-    // * When anything breaks, the shortcuts are just silently missing with no error reporting.
-    private fun updateShortcuts() {
-        val userManager = getSystemService(UserManager::class.java)
-        if (!userManager.isUserUnlocked) {
-            // We currently don't trigger anything when the user unlocks the device. It'll happen
-            // eventually when the app is unloaded from memory and the user reopens it or the
-            // scheduled job runs.
-            Log.w(TAG, "Cannot update dynamic shortcuts until unlocked")
-            return
-        }
-
-        val icon = IconCompat.createWithResource(this, R.mipmap.ic_launcher)
-        val intent = Intent(this, UpdaterLauncherActivity::class.java).apply {
-            // Action is required, but value doesn't matter.
-            action = Intent.ACTION_MAIN
-        }
-        val shortcut = ShortcutInfoCompat.Builder(this, Preferences.PREF_CHECK_FOR_UPDATES)
-            .setShortLabel(getString(R.string.pref_check_for_updates_name))
-            .setIcon(icon)
-            .setIntent(intent)
-            .build()
-        val shortcuts = listOf(shortcut)
-
-        if (!ShortcutManagerCompat.setDynamicShortcuts(this, shortcuts)) {
-            Log.w(TAG, "Failed to update dynamic shortcuts")
-        }
+        PostUnlockInit.initIfUnlocked(this)
     }
 
     companion object {

--- a/app/src/main/java/com/chiller3/custota/PostUnlockInit.kt
+++ b/app/src/main/java/com/chiller3/custota/PostUnlockInit.kt
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.custota
+
+import android.content.Context
+import android.content.Intent
+import android.os.UserManager
+import android.util.Log
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
+import com.chiller3.custota.updater.UpdaterJob
+import com.chiller3.custota.updater.UpdaterLauncherActivity
+
+object PostUnlockInit {
+    private val TAG = PostUnlockInit::class.java.simpleName
+
+    fun initIfUnlocked(context: Context) {
+        val userManager = context.getSystemService(UserManager::class.java)
+        if (!userManager.isUserUnlocked) {
+            Log.w(TAG, "Deferring init until after initial unlock")
+            return
+        }
+
+        Log.i(TAG, "Initializing items requiring credential-protected storage")
+
+        // Run preferences migrations.
+        Preferences(context).let {}
+
+        UpdaterJob.schedulePeriodic(context, false)
+
+        updateShortcuts(context)
+    }
+
+    // We don't use static shortcuts because:
+    // * There's no way to substitute in the package name. ${applicationId} only works in the
+    //   manifest and custom resource definitions are evaluated to @ref/<resource ID>.
+    // * When anything breaks, the shortcuts are just silently missing with no error reporting.
+    private fun updateShortcuts(context: Context) {
+        val icon = IconCompat.createWithResource(context, R.mipmap.ic_launcher)
+        val intent = Intent(context, UpdaterLauncherActivity::class.java).apply {
+            // Action is required, but value doesn't matter.
+            action = Intent.ACTION_MAIN
+        }
+        val shortcut = ShortcutInfoCompat.Builder(context, Preferences.PREF_CHECK_FOR_UPDATES)
+            .setShortLabel(context.getString(R.string.pref_check_for_updates_name))
+            .setIcon(icon)
+            .setIntent(intent)
+            .build()
+        val shortcuts = listOf(shortcut)
+
+        if (!ShortcutManagerCompat.setDynamicShortcuts(context, shortcuts)) {
+            Log.w(TAG, "Failed to update dynamic shortcuts")
+        }
+    }
+}

--- a/app/src/main/java/com/chiller3/custota/PostUnlockInitReceiver.kt
+++ b/app/src/main/java/com/chiller3/custota/PostUnlockInitReceiver.kt
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.custota
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class PostUnlockInitReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent?) {
+        if (intent?.action != Intent.ACTION_BOOT_COMPLETED) {
+            return
+        }
+
+        PostUnlockInit.initIfUnlocked(context)
+    }
+}

--- a/app/src/main/java/com/chiller3/custota/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/custota/settings/SettingsFragment.kt
@@ -125,10 +125,11 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClic
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         val context = requireContext()
 
+        // This Preferences instance is constructed first to ensure migrations are run, just in case
+        // we happen to run before PostUnlockInitReceiver.
+        prefs = Preferences(context)
         preferenceManager.setStorageDeviceProtected()
         setPreferencesFromResource(R.xml.preferences_root, rootKey)
-
-        prefs = Preferences(context)
 
         categoryCertificates = findPreference(Preferences.CATEGORY_CERTIFICATES)!!
         categoryDebug = findPreference(Preferences.CATEGORY_DEBUG)!!


### PR DESCRIPTION
The migration logic introduced in 5.12 was incorrect and allowed the migration to run while BFU. This marked the migration as completed, even though nothing was migrated, causing all settings to be reset.

This commit fixes the broken migration and also ensures that it will actually run when the user unlocks their device. If the user hasn't already reconfigured the app after the 5.12 upgrade, then the migration will be reattempted, even though it is marked as complete.