### PR TITLE
Show determinate progress bar for snapuserd merge

### DIFF
--- a/app/src/main/java/com/chiller3/custota/Notifications.kt
+++ b/app/src/main/java/com/chiller3/custota/Notifications.kt
@@ -89,6 +89,7 @@ class Notifications(
         progressCurrent: Int?,
         progressMax: Int?,
         showImmediately: Boolean,
+        showOnLockScreen: Boolean,
     ): Notification {
         require((progressCurrent == null) == (progressMax == null)) {
             "Must specify both current and max progress or neither"
@@ -109,6 +110,9 @@ class Notifications(
             setContentIntent(pendingIntent)
             setOngoing(true)
             setOnlyAlertOnce(true)
+            if (showOnLockScreen) {
+                setVisibility(Notification.VISIBILITY_PUBLIC)
+            }
 
             if (progressCurrent != null && progressMax != null) {
                 // We also show an indeterminate progress bar when the current progress is 0 because

--- a/app/src/main/java/com/chiller3/custota/updater/UpdaterService.kt
+++ b/app/src/main/java/com/chiller3/custota/updater/UpdaterService.kt
@@ -208,6 +208,10 @@ class UpdaterService : Service(), UpdaterThread.UpdaterThreadListener {
             state?.current,
             state?.max,
             showImmediately,
+            // Show progress on the lock screen only if there are no buttons for influencing the
+            // behavior of the current operation. This allows the progress bar for the post-reboot
+            // merge operation to show up while the device is BFU.
+            actionResIds.isEmpty(),
         )
 
         val type = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {


### PR DESCRIPTION
For some reason, update_engine only provides intermediate progress updates for the snapuserd merge operation if another callback is registered using `IUpdateEngine.cleanupSuccessfulUpdate()`. The primary callback only receives completion statuses. Weirdly, there's also no binder call to unregister this callback. It can't be removed until the merge operation completes or the binder client process dies. That is fine for Custota's use case since `UpdaterThread` does not exit until the operation is complete anyway.

This commit also updates the notification logic so that progress notifications that do not contain action buttons, like the one for merge operations, are allowed to be shown on the lock screen. This way, the user can see the progress while in BFU.