### PR TITLE
Fix possible crash with merge callback

### DIFF
--- a/app/src/main/java/com/chiller3/custota/updater/UpdaterThread.kt
+++ b/app/src/main/java/com/chiller3/custota/updater/UpdaterThread.kt
@@ -167,8 +167,15 @@ class UpdaterThread(
         // This cannot be unbound. The callback is removed from update_engine only when the merge
         // operation finishes or the binder client process dies.
         EngineCallback(EngineWatchType.MERGE).let {
-            updateEngine.cleanupSuccessfulUpdate(it)
+            // We set mergeCallback first because calling cleanupSuccessfulUpdate() may result in a
+            // synchronous call to onPayloadApplicationComplete(), which clears the callback.
             mergeCallback = it
+            try {
+                updateEngine.cleanupSuccessfulUpdate(it)
+            } catch (e: Exception) {
+                mergeCallback = null
+                throw e
+            }
         }
     }
 


### PR DESCRIPTION
In some scenarios, the merge callback can be cleared sooner than when it was initially set, tripping up the assertion we do in `unbind()`.