### PR TITLE
Work around r8 miscompilation in UpdaterThread exceptions

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -50,3 +50,9 @@
 -keep class com.chiller3.custota.standalone.* {
     *;
 }
+
+# These exception classes have no source-level differences, but are absolutely different
+# semantically. r8 wants to deduplicate them, which is just wrong.
+-keep class com.chiller3.custota.updater.UpdaterThread$*Exception {
+    *;
+}


### PR DESCRIPTION
r8 is deduplicating the exception classes. While they have identical source code class definitions, they are semantically different.