### PR TITLE
Remove Google Play dependency info block

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -188,6 +188,10 @@ android {
             excludes.add("META-INF/versions/9/OSGI-INF/MANIFEST.MF")
         }
     }
+    dependenciesInfo {
+        includeInApk = false
+        includeInBundle = false
+    }
 }
 
 kotlin {


### PR DESCRIPTION
This metadata is encrypted with Google's public key and is unreadable by anyone else. We have no need for this.