### PR TITLE
Add optional notification for post-reboot cleanup success

### DIFF
--- a/app/src/main/java/com/chiller3/custota/Notifications.kt
+++ b/app/src/main/java/com/chiller3/custota/Notifications.kt
@@ -24,6 +24,7 @@ class Notifications(
         const val CHANNEL_ID_CHECK = "check"
         const val CHANNEL_ID_FAILURE = "failure"
         const val CHANNEL_ID_SUCCESS = "success"
+        const val CHANNEL_ID_CLEANUP = "cleanup"
 
         private val LEGACY_CHANNEL_IDS = arrayOf<String>()
 
@@ -65,6 +66,14 @@ class Notifications(
         description = context.getString(R.string.notification_channel_success_desc)
     }
 
+    private fun createCleanupAlertsChannel() = NotificationChannel(
+        CHANNEL_ID_CLEANUP,
+        context.getString(R.string.notification_channel_cleanup_name),
+        NotificationManager.IMPORTANCE_NONE,
+    ).apply {
+        description = context.getString(R.string.notification_channel_cleanup_desc)
+    }
+
     /**
      * Ensure notification channels are up-to-date.
      *
@@ -76,6 +85,7 @@ class Notifications(
             createCheckAlertsChannel(),
             createFailureAlertsChannel(),
             createSuccessAlertsChannel(),
+            createCleanupAlertsChannel(),
         ))
         LEGACY_CHANNEL_IDS.forEach { notificationManager.deleteNotificationChannel(it) }
     }

--- a/app/src/main/java/com/chiller3/custota/updater/UpdaterService.kt
+++ b/app/src/main/java/com/chiller3/custota/updater/UpdaterService.kt
@@ -233,10 +233,19 @@ class UpdaterService : Service(), UpdaterThread.UpdaterThreadListener {
         val showReboot: Boolean
 
         when (result) {
-            is UpdaterThread.NothingToMonitor, is UpdaterThread.UpdateCleanedUp -> {
+            is UpdaterThread.NothingToMonitor -> {
                 // No need to bug the user about this since it's automatic and not directly caused
                 // in response to a user action.
                 return
+            }
+            is UpdaterThread.UpdateCleanedUp -> {
+                channel = Notifications.CHANNEL_ID_CLEANUP
+                onlyAlertOnce = false
+                titleResId = R.string.notification_update_ota_succeeded
+                message = null
+                showInstall = false
+                showRetry = false
+                showReboot = false
             }
             is UpdaterThread.UpdateAvailable -> {
                 channel = Notifications.CHANNEL_ID_CHECK

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,14 +81,16 @@
     <string name="dialog_action_cancel">Cancel</string>
 
     <!-- Notifications -->
-    <string name="notification_channel_persistent_name">background services</string>
-    <string name="notification_channel_persistent_desc">persistent notification for update progress</string>
-    <string name="notification_channel_check_name">update check alerts</string>
-    <string name="notification_channel_check_desc">alerts about updates being available</string>
-    <string name="notification_channel_failure_name">failure alerts</string>
-    <string name="notification_channel_failure_desc">alerts for errors during update</string>
-    <string name="notification_channel_success_name">success alerts</string>
-    <string name="notification_channel_success_desc">alerts for successful update</string>
+    <string name="notification_channel_persistent_name">Background services</string>
+    <string name="notification_channel_persistent_desc">Persistent notification for update progress</string>
+    <string name="notification_channel_check_name">Update check alerts</string>
+    <string name="notification_channel_check_desc">Alerts about updates being available</string>
+    <string name="notification_channel_failure_name">Failure alerts</string>
+    <string name="notification_channel_failure_desc">Alerts for errors during update</string>
+    <string name="notification_channel_success_name">Success alerts</string>
+    <string name="notification_channel_success_desc">Alerts for successful update</string>
+    <string name="notification_channel_cleanup_name">Cleanup alerts</string>
+    <string name="notification_channel_cleanup_desc">Alerts for successful cleanup after reboot</string>
     <string name="notification_state_init">Initializing OTA updater</string>
     <string name="notification_state_check">Checking for OTA updates</string>
     <string name="notification_state_install">Installing OTA update</string>


### PR DESCRIPTION
This is disabled by default, but can be enabled from Android's standard notification channel settings by the user if they want to be notified when the `snapuserd` merge operation is complete.

Fixes: #170