### PR TITLE
post-fs-data.sh: Create directories with mkdir -p

### DIFF
--- a/custota-tool/system-ca-certs/post-fs-data.sh
+++ b/custota-tool/system-ca-certs/post-fs-data.sh
@@ -33,7 +33,7 @@ for cert_dir in "${apex_dir}" "${system_dir}"; do
     mnt_dir=${mnt_base}/${mnt_index}
     let mnt_index+=1
 
-    mkdir "${mnt_dir}"
+    mkdir -p "${mnt_dir}"
     nsenter --mount=/proc/1/ns/mnt -- \
         mount -t tmpfs "${module_id}" "${mnt_dir}"
 


### PR DESCRIPTION
`$mnt_dir` was not created with `mkdir -p`, unlike `$mnt_base`. This caused the system-ca-certs module to only work for the first boot after it was enabled, since `mkdir` would fail on subsequent boots.

Log:
```
+ mod_dir=/data/adb/modules/system_ca_certs
+ module_prop id
+ grep '^id=' /data/adb/modules/system_ca_certs/module.prop
+ cut '-d=' -f2
+ module_id=system_ca_certs
+ apex_dir=/apex/com.android.conscrypt/cacerts
+ system_dir=/system/etc/security/cacerts
+ mnt_base=/data/adb/modules/system_ca_certs/mnt
+ mnt_index=0
+ mkdir -p /data/adb/modules/system_ca_certs/mnt
+ '[[' '!' -d /apex/com.android.conscrypt/cacerts ]]
+ mnt_dir=/data/adb/modules/system_ca_certs/mnt/0
+ let 'mnt_index+=1'
+ mkdir /data/adb/modules/system_ca_certs/mnt/0
mkdir: can't create directory '/data/adb/modules/system_ca_certs/mnt/0': File exists
```