### PR TITLE
proguard: Keep mContext from {Single,Tree}DocumentFile

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -39,6 +39,17 @@
     *;
 }
 
+# We construct TreeDocumentFile via reflection in DocumentFileExtensions
+# to speed up SAF performance when doing path lookups.
+-keepclassmembers class androidx.documentfile.provider.SingleDocumentFile {
+    private android.content.Context mContext;
+}
+-keepclassmembers class androidx.documentfile.provider.TreeDocumentFile {
+    <init>(androidx.documentfile.provider.DocumentFile, android.content.Context, android.net.Uri);
+
+    private android.content.Context mContext;
+}
+
 # Keep standalone CLI utilities
 -keep class com.chiller3.custota.standalone.* {
     void main(java.lang.String[]);


### PR DESCRIPTION
ca94b0d31a5348346dfa3da639d62678920ff7d0 introduced the regression, which broke the looking up of local files when installing from a local directory.

Fixes: #189