### PR TITLE
Minor fixes to Compose UI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -174,7 +174,6 @@ android {
         aidl = true
         compose = true
         buildConfig = true
-        viewBinding = true
     }
     lint {
         // The translations are always going to lag behind new strings being

--- a/app/src/main/java/com/chiller3/custota/settings/ErrorDetailsDialog.kt
+++ b/app/src/main/java/com/chiller3/custota/settings/ErrorDetailsDialog.kt
@@ -9,6 +9,7 @@ package com.chiller3.custota.settings
 
 import android.content.ClipData
 import android.content.ClipboardManager
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Text
@@ -33,7 +34,9 @@ fun ErrorDetailsDialog(
         },
         text = {
             message?.let {
-                Text(text = it)
+                SelectionContainer {
+                    Text(text = it)
+                }
             }
         },
         onDismissRequest = onDismiss,

--- a/app/src/main/java/com/chiller3/custota/settings/OtaSourceDialog.kt
+++ b/app/src/main/java/com/chiller3/custota/settings/OtaSourceDialog.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.OutlinedButton
@@ -22,6 +24,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -50,10 +53,9 @@ fun OtaSourceDialog(
         mutableStateOf(if (isLocal) initialUri else null)
     }
 
-    var input by rememberSaveable {
-        mutableStateOf(if (isLocal) "" else initialUri?.toString() ?: "")
-    }
-    val uriRemote = tryParseInput(input)
+    val initialText = remember { if (isLocal) "" else initialUri?.toString() ?: "" }
+    val input = rememberTextFieldState(initialText = initialText)
+    val uriRemote = tryParseInput(input.text.toString())
 
     val requestSafDirectory = rememberLauncherForActivityResult(OpenPersistentDocumentTree()) { uri ->
         uri?.let {
@@ -78,9 +80,8 @@ fun OtaSourceDialog(
                     }
                 } else {
                     OutlinedTextField(
+                        state = input,
                         modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
-                        value = input,
-                        onValueChange = { input = it },
                         placeholder = {
                             Text(text = stringResource(R.string.dialog_ota_source_server_url_hint))
                         },
@@ -95,6 +96,7 @@ fun OtaSourceDialog(
                             keyboardType = KeyboardType.Uri,
                             autoCorrectEnabled = false,
                         ),
+                        lineLimits = TextFieldLineLimits.SingleLine,
                     )
                 }
             }

--- a/app/src/main/java/com/chiller3/custota/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/chiller3/custota/settings/SettingsScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.net.toUri
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.chiller3.custota.BuildConfig
@@ -295,9 +296,11 @@ fun SettingsScreen(viewModel: SettingsViewModel = viewModel()) {
         )
     }
 
-    LaunchedEffect(Unit) {
+    LifecycleResumeEffect(Unit) {
         // Make sure we refresh this every time the user switches back to the app.
         viewModel.refreshBootloaderStatus()
+
+        onPauseOrDispose {}
     }
 }
 

--- a/app/src/main/java/com/chiller3/custota/ui/Screen.kt
+++ b/app/src/main/java/com/chiller3/custota/ui/Screen.kt
@@ -45,8 +45,8 @@ fun AppScreen(
         },
         containerColor = PreferenceDefaults.containerColor,
     ) { contentPadding ->
-        val outerPadding = contentPadding.copy(bottom = 0.dp)
-        val innerPadding = contentPadding.copy(start = 0.dp, top = 0.dp, end = 0.dp)
+        val outerPadding = contentPadding.copy(start = 0.dp, end = 0.dp, bottom = 0.dp)
+        val innerPadding = contentPadding.copy(top = 0.dp)
 
         Box(modifier = Modifier.padding(outerPadding)) {
             content(AppScreenParams(


### PR DESCRIPTION
- Adjust window insets to allow scrolling from inset region
- Make error dialog text selectable
- Use `TextFieldState` for all `TextField`s
- Make `TextField`s single line where appropriate
- Remove viewbinding generation now that we don't use views
- Fix bootloader status not immediately updating after toggling OEM unlocking and returning to the app