### PR TITLE
Add notification action to retry with full OTA when incremental OTA fails

### DIFF
--- a/app/src/main/java/com/chiller3/custota/updater/UpdaterService.kt
+++ b/app/src/main/java/com/chiller3/custota/updater/UpdaterService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023-2025 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -10,6 +10,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.net.Network
+import android.net.Uri
 import android.os.Build
 import android.os.Handler
 import android.os.IBinder
@@ -75,7 +76,7 @@ class UpdaterService : Service(), UpdaterThread.UpdaterThreadListener {
             }
         } catch (e: Exception) {
             Log.w(TAG, "Failed to handle intent: $intent", e)
-            notifyAlert(UpdaterThread.UpdateFailed(e.toSingleLineString()))
+            notifyAlert(UpdaterThread.UpdateFailed(e.toSingleLineString(), false))
         }
 
         tryStop()
@@ -230,6 +231,7 @@ class UpdaterService : Service(), UpdaterThread.UpdaterThreadListener {
         val message: String?
         val showInstall: Boolean
         val showRetry: Boolean
+        val showRetryFull: Boolean
         val showReboot: Boolean
 
         when (result) {
@@ -245,6 +247,7 @@ class UpdaterService : Service(), UpdaterThread.UpdaterThreadListener {
                 message = null
                 showInstall = false
                 showRetry = false
+                showRetryFull = false
                 showReboot = false
             }
             is UpdaterThread.UpdateAvailable -> {
@@ -255,6 +258,7 @@ class UpdaterService : Service(), UpdaterThread.UpdaterThreadListener {
                 message = result.fingerprints.joinToString("\n")
                 showInstall = true
                 showRetry = false
+                showRetryFull = false
                 showReboot = false
             }
             UpdaterThread.UpdateUnnecessary -> {
@@ -270,6 +274,7 @@ class UpdaterService : Service(), UpdaterThread.UpdaterThreadListener {
                 message = null
                 showInstall = false
                 showRetry = false
+                showRetryFull = false
                 showReboot = false
             }
             UpdaterThread.UpdateSucceeded, UpdaterThread.UpdateNeedReboot -> {
@@ -280,6 +285,7 @@ class UpdaterService : Service(), UpdaterThread.UpdaterThreadListener {
                 message = null
                 showInstall = false
                 showRetry = false
+                showRetryFull = false
                 showReboot = true
             }
             UpdaterThread.UpdateReverted -> {
@@ -289,6 +295,7 @@ class UpdaterService : Service(), UpdaterThread.UpdaterThreadListener {
                 message = null
                 showInstall = false
                 showRetry = false
+                showRetryFull = false
                 showReboot = false
             }
             UpdaterThread.UpdateCancelled -> {
@@ -298,15 +305,23 @@ class UpdaterService : Service(), UpdaterThread.UpdaterThreadListener {
                 message = null
                 showInstall = false
                 showRetry = true
+                showRetryFull = false
                 showReboot = false
             }
             is UpdaterThread.UpdateFailed -> {
                 channel = Notifications.CHANNEL_ID_FAILURE
                 onlyAlertOnce = false
                 titleResId = R.string.notification_update_ota_failed
-                message = result.errorMsg
+                message = buildString {
+                    append(result.errorMsg)
+                    if (result.isIncremental) {
+                        append("\n\n")
+                        append(getString(R.string.notification_update_ota_failed_incremental))
+                    }
+                }
                 showInstall = false
                 showRetry = true
+                showRetryFull = result.isIncremental
                 showReboot = false
             }
             UpdaterThread.BrokenNetworkApi -> {
@@ -319,6 +334,7 @@ class UpdaterService : Service(), UpdaterThread.UpdaterThreadListener {
                 )
                 showInstall = false
                 showRetry = true
+                showRetryFull = false
                 showReboot = false
             }
         }
@@ -332,10 +348,14 @@ class UpdaterService : Service(), UpdaterThread.UpdaterThreadListener {
         }
         if (showRetry) {
             actionResIds.add(R.string.notification_action_retry)
-            // Go through job scheduler because we might need a new network
+            // Go through job scheduler because we might need a new network.
             updaterAction?.let { action ->
                 actionIntents.add(createScheduleIntent(this, action))
             }
+        }
+        if (showRetryFull) {
+            actionResIds.add(R.string.notification_action_retry_full)
+            actionIntents.add(createScheduleIntent(this, UpdaterThread.Action.INSTALL_FULL))
         }
         if (showReboot) {
             actionResIds.add(R.string.notification_action_reboot)
@@ -415,6 +435,9 @@ class UpdaterService : Service(), UpdaterThread.UpdaterThreadListener {
             action: UpdaterThread.Action,
         ) = Intent(context, UpdaterService::class.java).apply {
             this.action = ACTION_SCHEDULE
+
+            // Unused, but guarantees filterEquals() uniqueness for use with PendingIntents.
+            data = Uri.fromParts("unused", action.name, null)
 
             val parcelableAction: Parcelable = action
             putExtra(EXTRA_ACTION, parcelableAction)

--- a/app/src/main/java/com/chiller3/custota/updater/UpdaterThread.kt
+++ b/app/src/main/java/com/chiller3/custota/updater/UpdaterThread.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023-2025 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -627,7 +627,12 @@ class UpdaterThread(
         val vbmetaDigest = SystemPropertiesProxy.get(PROP_VBMETA_DIGEST)
         Log.d(TAG, "Current vbmeta digest: $vbmetaDigest")
 
-        val locationInfo = updateInfo.incremental[vbmetaDigest] ?: updateInfo.full
+        val incrementalInfo = if (action == Action.INSTALL_FULL) {
+            null
+        } else {
+            updateInfo.incremental[vbmetaDigest]
+        }
+        val locationInfo = incrementalInfo ?: updateInfo.full
         val isIncremental = locationInfo !== updateInfo.full
         Log.d(TAG, "OTA is incremental: $isIncremental")
 
@@ -669,6 +674,7 @@ class UpdaterThread(
             fingerprints,
             otaUri,
             csigInfo,
+            isIncremental,
         )
     }
 
@@ -793,6 +799,7 @@ class UpdaterThread(
 
         val pm = context.getSystemService(PowerManager::class.java)
         val wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, TAG)
+        var isIncremental = false
 
         try {
             wakeLock.acquire()
@@ -819,7 +826,7 @@ class UpdaterThread(
                 if (newStatus == UpdateEngineStatus.IDLE) {
                     listener.onUpdateResult(this, UpdateReverted)
                 } else {
-                    listener.onUpdateResult(this, UpdateFailed(newStatusStr))
+                    listener.onUpdateResult(this, UpdateFailed(newStatusStr, isIncremental))
                 }
             } else if (status == UpdateEngineStatus.UPDATED_NEED_REBOOT) {
                 // Resend success notification to remind the user to reboot. We can't perform any
@@ -838,6 +845,7 @@ class UpdaterThread(
                     listener.onUpdateProgress(this, ProgressType.CHECK, 0, 0)
 
                     val checkUpdateResult = checkForUpdates()
+                    isIncremental = checkUpdateResult.isIncremental
 
                     if (!checkUpdateResult.updateAvailable) {
                         // Update not needed.
@@ -895,7 +903,7 @@ class UpdaterThread(
             if (e.findCause(BrokenNetworkApiException::class.java) != null) {
                 listener.onUpdateResult(this, BrokenNetworkApi)
             } else {
-                listener.onUpdateResult(this, UpdateFailed(e.toSingleLineString()))
+                listener.onUpdateResult(this, UpdateFailed(e.toSingleLineString(), isIncremental))
             }
         } finally {
             wakeLock.release()
@@ -923,6 +931,7 @@ class UpdaterThread(
         val fingerprints: List<String>,
         val otaUri: Uri,
         val csigInfo: CsigInfo,
+        val isIncremental: Boolean,
     )
 
     @Serializable
@@ -972,19 +981,22 @@ class UpdaterThread(
 
     @Parcelize
     enum class Action : Parcelable {
+        // The order cannot ever change because UpdaterJob uses ordinal in the persisted bundle for
+        // the scheduled job.
         MONITOR,
         CHECK,
         INSTALL,
-        REVERT;
+        REVERT,
+        INSTALL_FULL;
 
         val requiresNetwork: Boolean
-            get() = this == CHECK || this == INSTALL
+            get() = this == CHECK || this == INSTALL || this == INSTALL_FULL
 
         val performsLargeDownloads: Boolean
-            get() = this == INSTALL
+            get() = this == INSTALL || this == INSTALL_FULL
 
         val usesSignificantBattery: Boolean
-            get() = this == INSTALL
+            get() = this == INSTALL || this == INSTALL_FULL
     }
 
     sealed interface Result
@@ -1006,7 +1018,7 @@ class UpdaterThread(
 
     data object UpdateCancelled : Result
 
-    data class UpdateFailed(val errorMsg: String) : Result
+    data class UpdateFailed(val errorMsg: String, val isIncremental: Boolean) : Result
 
     data object BrokenNetworkApi : Result
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,6 +107,7 @@
     <string name="notification_update_ota_cancelled">OTA update process was cancelled</string>
     <string name="notification_update_ota_reverted">Successfully reverted OTA update</string>
     <string name="notification_update_ota_failed">Failed to install OTA update</string>
+    <string name="notification_update_ota_failed_incremental">Retry installing this incremental OTA again or try installing the full OTA instead.</string>
     <string name="notification_broken_network_api_title">Cannot use network pinning</string>
     <string name="notification_broken_network_api_message">Custota was blocked from pinning network connections to a specific network ID. To work around this, see the \"%s\" option after enabling debug mode by long-pressing Custota\'s version number.</string>
     <string name="notification_action_install">Install</string>
@@ -115,6 +116,7 @@
     <string name="notification_action_cancel">Cancel</string>
     <string name="notification_action_reboot">Reboot</string>
     <string name="notification_action_retry">Retry</string>
+    <string name="notification_action_retry_full">Try full OTA</string>
 
     <!-- Alerts -->
     <string name="action_details">Details</string>


### PR DESCRIPTION
This will only work in the `UpdaterThread` instance that started the installation. If the app is force quit and then restarted (in monitor mode), it won't know that the ongoing installation is for an incremental OTA.

Fixes: #214